### PR TITLE
fix: update project_type

### DIFF
--- a/.github/workflows/on-push-to-release.yaml
+++ b/.github/workflows/on-push-to-release.yaml
@@ -39,7 +39,7 @@ jobs:
         with:
           project_status: official
           project_stability: alpha
-          project_type: sdk
+          project_type: other
 
       - name: Commitlint and Other Shared Build Steps
         uses: momentohq/standards-and-practices/github-actions/shared-build@gh-actions-v1


### PR DESCRIPTION
The release workflow failed because project_type was sdk yet sdk_language property wasn't provided.
Updated project_type to other.