### PR TITLE
chore: update `client-sdk-php` version to `0.2.1`

### DIFF
--- a/.github/workflows/on-push-to-main.yaml
+++ b/.github/workflows/on-push-to-main.yaml
@@ -7,7 +7,6 @@ on:
 jobs:
   generate-readme:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/on-push-to-release.yaml
+++ b/.github/workflows/on-push-to-release.yaml
@@ -12,7 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set release
-        id: semrel
         uses: go-semantic-release/action@v1
         with:
           github-token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
@@ -24,19 +23,3 @@ jobs:
           # https://github.com/go-semantic-release/semantic-release/blob/master/cmd/semantic-release/main.go#L173-L194
           # https://github.com/go-semantic-release/condition-github/blob/4c8af3fc516151423fff2f77eb08bf7082570676/pkg/condition/github.go#L42-L44
           custom-arguments: "--no-ci"
-
-      - name: Output release
-        id: release
-        run: echo "::set-output name=release::${{ steps.semrel.outputs.version }}"
-
-  verify-readme:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Verify README generation
-        uses: momentohq/standards-and-practices/github-actions/oss-readme-template@gh-actions-v1
-        with:
-          project_status: official
-          project_stability: alpha
-          project_type: other

--- a/.github/workflows/on-push-to-release.yaml
+++ b/.github/workflows/on-push-to-release.yaml
@@ -5,13 +5,26 @@ on:
     branches: [ release ]
 
 jobs:
+  verify-readme:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Verify README generation
+        uses: momentohq/standards-and-practices/github-actions/oss-readme-template@gh-actions-v1
+        with:
+          project_status: official
+          project_stability: alpha
+          project_type: other
   release:
     runs-on: ubuntu-latest
+    needs: [ verify-readme ]
     outputs:
       version: ${{ steps.release.outputs.release }}
     steps:
       - uses: actions/checkout@v3
       - name: Set release
+        id: semrel
         uses: go-semantic-release/action@v1
         with:
           github-token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
-
+.phpunit.cache
+.phpunit.result.cache
+.idea/
 /vendor/

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "momentohq/client-sdk-php": "0.2.0"
+    "momentohq/client-sdk-php": "0.2.1"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "61d6ab11f413d53416b236d2a0c4d096",
+    "content-hash": "d875c95110da03f3505a1f61394f420c",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -158,16 +158,16 @@
         },
         {
             "name": "momentohq/client-sdk-php",
-            "version": "v0.2.0",
+            "version": "v0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/momentohq/client-sdk-php.git",
-                "reference": "a0e2045e45fb8d6098c351f35135c807d8d386a6"
+                "reference": "35f5a73b7ffaed282f3ac00ac4a239171a39236f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/momentohq/client-sdk-php/zipball/a0e2045e45fb8d6098c351f35135c807d8d386a6",
-                "reference": "a0e2045e45fb8d6098c351f35135c807d8d386a6",
+                "url": "https://api.github.com/repos/momentohq/client-sdk-php/zipball/35f5a73b7ffaed282f3ac00ac4a239171a39236f",
+                "reference": "35f5a73b7ffaed282f3ac00ac4a239171a39236f",
                 "shasum": ""
             },
             "require": {
@@ -204,10 +204,10 @@
                 }
             },
             "support": {
-                "source": "https://github.com/momentohq/client-sdk-php/tree/v0.2.0",
+                "source": "https://github.com/momentohq/client-sdk-php/tree/v0.2.1",
                 "issues": "https://github.com/momentohq/client-sdk-php/issues"
             },
-            "time": "2022-10-27T21:15:38+00:00"
+            "time": "2022-11-08T21:33:21+00:00"
         }
     ],
     "packages-dev": [],

--- a/src/MomentoTaggedCache.php
+++ b/src/MomentoTaggedCache.php
@@ -31,9 +31,14 @@ class MomentoTaggedCache extends TaggedCache
         $value = null;
         foreach ($tags as $tag) {
             $keys = $this->store->setFetch($cacheName, $tag);
-            foreach ($keys as $k) {
-                if ($k == $key) {
-                    $value = $this->store->get($key);
+            if (is_null($keys)) {
+                return $value;
+            } else {
+                foreach ($keys as $k) {
+                    if ($k == $key) {
+                        $value = $this->store->get($key);
+                        break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Updated `client-sdk-php` version to `0.2.1` to make `setAdd` and `setFetch` available.
Also updated TaggedCache get logic so that when no key is found associated with provided tags, it will return `nulll`.
