### PR TITLE
fix: generate README on push to main GH workflow

### DIFF
--- a/.github/workflows/on-push-to-main.yaml
+++ b/.github/workflows/on-push-to-main.yaml
@@ -2,7 +2,7 @@ name: On push to main
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   test:
@@ -16,17 +16,10 @@ jobs:
         with:
           token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
 
-      - name: Generate README
-        uses: momentohq/standards-and-practices/github-actions/generate-and-commit-oss-readme@gh-actions-v1
-        with:
-          project_status: official
-          project_stability: alpha
-          project_type: other
-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: "8.0"
           extensions: grpc
           tools: composer
 
@@ -35,3 +28,10 @@ jobs:
 
       - name: Run tests
         run: php vendor/phpunit/phpunit/phpunit --configuration phpunit.xml
+
+      - name: Generate README
+        uses: momentohq/standards-and-practices/github-actions/generate-and-commit-oss-readme@gh-actions-v1
+        with:
+          project_status: official
+          project_stability: alpha
+          project_type: other


### PR DESCRIPTION
Brought the generate README step to the last in the `on-push-to-main` workflow so that README will actually be generated based on the template.