### PR TITLE
chore: update to API Key

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -9,7 +9,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-      MOMENTO_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+      MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
       MOMENTO_CACHE_NAME: laravel-cache-test
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/on-push-to-main.yaml
+++ b/.github/workflows/on-push-to-main.yaml
@@ -12,7 +12,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     env:
-      MOMENTO_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+      MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
       MOMENTO_CACHE_NAME: laravel-cache-test
 
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Check out our SDK [requirements](https://github.com/momentohq/laravel-cache#requ
 ## Run Integration Test
 
 ```bash
-export MOMENTO_AUTH_TOKEN=<YOUR_AUTH_TOKEN>
+export MOMENTO_API_KEY=<YOUR_AUTH_TOKEN>
 export MOMENTO_CACHE_NAME=<YOUR_CACHE_NAME>
 php vendor/phpunit/phpunit/phpunit --configuration phpunit.xml
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Check out our SDK [requirements](https://github.com/momentohq/laravel-cache#requ
 ## Run Integration Test
 
 ```bash
-export MOMENTO_API_KEY=<YOUR_AUTH_TOKEN>
+export MOMENTO_API_KEY=<YOUR_API_KEY>
 export MOMENTO_CACHE_NAME=<YOUR_CACHE_NAME>
 php vendor/phpunit/phpunit/phpunit --configuration phpunit.xml
 ```

--- a/README.template.md
+++ b/README.template.md
@@ -4,8 +4,8 @@
 
 ### Requirements
 
-- A Momento Auth Token is required, you can generate one using
-  the [Momento CLI](https://github.com/momentohq/momento-cli)
+- A Momento API Key is required, you can generate one using
+  the [Momento Console](https://console.gomomento.com)
 - At least PHP 8.0
 - [Composer](https://getcomposer.org/doc/00-intro.md)
 - At least [Laravel 9.x](https://laravel.com/docs/9.x/installation)
@@ -26,7 +26,7 @@ Add our SDK as a dependency to your Laravel installation's `composer.json` file:
 ```json
 {
   "require": {
-    "momentohq/laravel-cache": "1.0.2"
+    "momentohq/laravel-cache": "1.0.4"
   }
 }
 ```

--- a/README.template.md
+++ b/README.template.md
@@ -42,6 +42,8 @@ Then, add `MomentoServiceProvider` to your `config/app.php`:
 ];
 ```
 
+And add `MOMENTO_API_KEY`=<YOUR_API_KEY> into your `.env` file
+
 Finally, add the required config to your `config/cache.php`:
 
 ```php

--- a/src/MomentoStore.php
+++ b/src/MomentoStore.php
@@ -16,7 +16,7 @@ class MomentoStore extends TaggableStore
 
     public function __construct(string $cacheName, int $defaultTtl)
     {
-        $authProvider = new EnvMomentoTokenProvider('MOMENTO_AUTH_TOKEN');
+        $authProvider = new EnvMomentoTokenProvider('MOMENTO_API_KEY');
         $configuration = Laptop::latest();
         $this->client = new CacheClient($configuration, $authProvider, $defaultTtl);
         $this->cacheName = $cacheName;

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -27,8 +27,8 @@ abstract class BaseTest extends Orchestra\Testbench\TestCase
      */
     protected function setUp(): void
     {
-        if (!getenv('MOMENTO_CACHE_NAME') || !getenv('MOMENTO_AUTH_TOKEN')) {
-            throw new UnknownError("Environment variables named MOMENTO_CACHE_NAME and MOMENTO_AUTH_TOKEN must be set.");
+        if (!getenv('MOMENTO_CACHE_NAME') || !getenv('MOMENTO_API_KEY')) {
+            throw new UnknownError("Environment variables named MOMENTO_CACHE_NAME and MOMENTO_API_KEY must be set.");
         }
         parent::setUp();
         app('cache')->extend('momento', function ($app, $config) {


### PR DESCRIPTION
Updated the word `auth token` to `API key`, and also updated the READM to direct users to use our console to generate an API key instead on our CLI which is deprecated. 